### PR TITLE
Fix async stub detection in test runner

### DIFF
--- a/src/service/runTestsSuite.ts
+++ b/src/service/runTestsSuite.ts
@@ -52,9 +52,12 @@ export function runTestsSuite(testSuite: TestSuite) {
     for (const test of testSuite.tests) {
       if (test.stub) {
         const { obj, method, returnValue } = test.stub;
+        const targetFn = typeof method === 'string' ? obj[method] : method;
+        const isAsync =
+          targetFn && targetFn.constructor && targetFn.constructor.name === 'AsyncFunction';
         if (returnValue instanceof Error) {
           sinon.replace(obj, method, sinon.fake.throws(returnValue) as any);
-        } else if (method.async) {
+        } else if (isAsync) {
           sinon.replace(obj, method, sinon.fake.resolves(returnValue) as any);
         } else {
           sinon.replace(obj, method, sinon.fake.returns(returnValue) as any);


### PR DESCRIPTION
## Summary
- handle detection of async functions when creating Sinon stubs

## Testing
- `npm test` *(fails: ts-node and sinon are missing)*

------
https://chatgpt.com/codex/tasks/task_e_684430e4ed9c832f93c61a6b061418f9